### PR TITLE
Fixed PHPNG compatibility - parameter names must be unique

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -222,7 +222,7 @@ class Finder extends Nette\Object implements \IteratorAggregate
 
 		if ($this->exclude) {
 			$filters = $this->exclude;
-			$iterator = new RecursiveCallbackFilterIterator($iterator, function($foo, $foo, $file) use ($filters) {
+			$iterator = new RecursiveCallbackFilterIterator($iterator, function($foo, $bar, $file) use ($filters) {
 				if (!$file->isDot() && !$file->isFile()) {
 					foreach ($filters as $filter) {
 						if (!call_user_func($filter, $file)) {
@@ -241,7 +241,7 @@ class Finder extends Nette\Object implements \IteratorAggregate
 
 		if ($this->groups) {
 			$groups = $this->groups;
-			$iterator = new CallbackFilterIterator($iterator, function($foo, $foo, $file) use ($groups) {
+			$iterator = new CallbackFilterIterator($iterator, function($foo, $bar, $file) use ($groups) {
 				foreach ($groups as $filters) {
 					foreach ($filters as $filter) {
 						if (!call_user_func($filter, $file)) {


### PR DESCRIPTION
Parameters of same names are forbidden in PHPNG (upcoming PHP 7):

```
Compile Error
Redefinition of parameter foo
```
