### PR TITLE
Finder: implement Countable

### DIFF
--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -24,7 +24,7 @@ use Nette,
  *
  * @author     David Grudl
  */
-class Finder extends Nette\Object implements \IteratorAggregate
+class Finder extends Nette\Object implements \IteratorAggregate, \Countable
 {
 	/** @var array */
 	private $paths = array();
@@ -185,6 +185,16 @@ class Finder extends Nette\Object implements \IteratorAggregate
 
 
 	/********************* iterator generator ****************d*g**/
+
+
+	/**
+	 * Get the number of found files and/or directories.
+	 * @return int
+	 */
+	public function count()
+	{
+		return iterator_count($this->getIterator());
+	}
 
 
 	/**

--- a/tests/Finder/Finder.basic.phpt
+++ b/tests/Finder/Finder.basic.phpt
@@ -20,6 +20,12 @@ function export($iterator)
 }
 
 
+test(function() { // count the results
+	$finder = Finder::findFiles('file.txt')->in('files');
+	Assert::count(1, $finder);
+});
+
+
 test(function() { // non-recursive file search
 	$finder = Finder::findFiles('file.txt')->in('files');
 	Assert::same(array('files/file.txt'), export($finder));


### PR DESCRIPTION
This will enable us to use `$size = count($finder);` instead of `$size = iterator_count($finder);`.